### PR TITLE
Disable autoblock

### DIFF
--- a/svyblockui/blockui/blockui.js
+++ b/svyblockui/blockui/blockui.js
@@ -2,6 +2,7 @@ angular.module('svyBlockUI', ['servoy', 'blockUI']).config(function(blockUIConfi
 	blockUIConfig.blockBrowserNavigation = true;
 	blockUIConfig.resetOnException = true;
 	blockUIConfig.message = null;
+	blockUIConfig.autoBlock = false;
 }).factory("svyBlockUI", function($services, $timeout, blockUI, blockUIConfig) {
 		
 		var scope = $services.getServiceScope('svyBlockUI');


### PR DESCRIPTION
Because it's unexpected behavior in the svyBlockUI plugin that you get a blocked ui independant of the .show()/.stop methods of the plugin AND because the autoblock behavior interferes with requestFocus(), as it is hardcoded to set the focus on the body of the HTML page (for some reason)